### PR TITLE
update tsschecker submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external/tsschecker"]
 	path = external/tsschecker
-	url = https://github.com/DanTheMann15/tsschecker
+	url = https://github.com/DanTheMann15/tsschecker.git
 [submodule "external/idevicerestore"]
 	path = external/idevicerestore
 	url = https://github.com/marijuanARM/idevicerestore.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "external/tsschecker"]
 	path = external/tsschecker
-	url = https://github.com/tihmstar/tsschecker.git
+	url = https://github.com/DanTheMann15/tsschecker
 [submodule "external/idevicerestore"]
 	path = external/idevicerestore
 	url = https://github.com/marijuanARM/idevicerestore.git


### PR DESCRIPTION
hey there, i recommend updating the tsschecker submodule with the one from my repository.
https://github.com/DanTheMann15/tsschecker

the reason why is because tihmstar's repository is (at the current time) out of date and doesn't correctly support the newer devices, among a couple of other bugs that might be restore-breaking (such as the wrong bbgcid for iPad7,12).

See [tihmstar/tsschecker=pull#165](https://github.com/tihmstar/tsschecker/pull/165) for more details.

you can see the commit history inside my [repository](https://github.com/DanTheMann15/tsschecker/commits/master) if you wish to see the changes.

take care!