### PR TITLE
Fix --exit-recovery, fix --latest flags for device models that have multiple boardconfigs

### DIFF
--- a/futurerestore/futurerestore.cpp
+++ b/futurerestore/futurerestore.cpp
@@ -162,7 +162,10 @@ void futurerestore::setAutoboot(bool val){
     retassure(_didInit, "did not init\n");
 
     retassure(getDeviceMode(false) == MODE_RECOVERY, "can't set auto-boot, when device isn't in recovery mode\n");
-    retassure(!_client->recovery && recovery_client_new(_client),"Could not connect to device in recovery mode.\n");
+    if(!_client->recovery)
+    {
+        retassure(!recovery_client_new(_client),"Could not connect to device in recovery mode.\n");
+    }
     retassure(!recovery_set_autoboot(_client, val),"Setting auto-boot failed?!\n");
 }
 

--- a/futurerestore/futurerestore.cpp
+++ b/futurerestore/futurerestore.cpp
@@ -1240,7 +1240,7 @@ char *futurerestore::getLatestFirmwareUrl(){
 
 void futurerestore::loadLatestBaseband(){
     char * manifeststr = getLatestManifest();
-    char *pathStr = getPathOfElementInManifest("BasebandFirmware", manifeststr, getDeviceModelNoCopy(), 0);
+    char *pathStr = getPathOfElementInManifest("BasebandFirmware", manifeststr, getDeviceBoardNoCopy(), 0);
     info("downloading Baseband\n\n");
     retassure(!downloadPartialzip(getLatestFirmwareUrl(), pathStr, _basebandPath = BASEBAND_TMP_PATH), "could not download baseband\n");
     saveStringToFile(manifeststr, BASEBAND_MANIFEST_TMP_PATH);
@@ -1250,7 +1250,7 @@ void futurerestore::loadLatestBaseband(){
 
 void futurerestore::loadLatestSep(){
     char * manifeststr = getLatestManifest();
-    char *pathStr = getPathOfElementInManifest("SEP", manifeststr, getDeviceModelNoCopy(), 0);
+    char *pathStr = getPathOfElementInManifest("SEP", manifeststr, getDeviceBoardNoCopy(), 0);
     info("downloading SEP\n\n");
     retassure(!downloadPartialzip(getLatestFirmwareUrl(), pathStr, SEP_TMP_PATH), "could not download SEP\n");
     loadSep(SEP_TMP_PATH);
@@ -1407,13 +1407,13 @@ plist_t futurerestore::loadPlistFromFile(const char *path){
     return ret;
 }
 
-char *futurerestore::getPathOfElementInManifest(const char *element, const char *manifeststr, const char *model, int isUpdateInstall){
+char *futurerestore::getPathOfElementInManifest(const char *element, const char *manifeststr, const char *boardConfig, int isUpdateInstall){
     char *pathStr = NULL;
     ptr_smart<plist_t> buildmanifest(NULL,plist_free);
     
     plist_from_xml(manifeststr, (uint32_t)strlen(manifeststr), &buildmanifest);
     
-    if (plist_t identity = getBuildidentity(buildmanifest._p, model, isUpdateInstall))
+    if (plist_t identity = getBuildidentityWithBoardconfig(buildmanifest._p, boardConfig, isUpdateInstall))
         if (plist_t manifest = plist_dict_get_item(identity, "Manifest"))
             if (plist_t elem = plist_dict_get_item(manifest, element))
                 if (plist_t info = plist_dict_get_item(elem, "Info"))

--- a/futurerestore/futurerestore.hpp
+++ b/futurerestore/futurerestore.hpp
@@ -118,7 +118,7 @@ public:
     static uint64_t getEcidFromSCAB(const char* scab, size_t scabSize);
     static plist_t loadPlistFromFile(const char *path);
     static void saveStringToFile(const char *str, const char *path);
-    static char *getPathOfElementInManifest(const char *element, const char *manifeststr, const char *model, int isUpdateInstall);
+    static char *getPathOfElementInManifest(const char *element, const char *manifeststr, const char *boardConfig, int isUpdateInstall);
     static std::string getGeneratorFromSHSH2(const plist_t shsh2);
 };
 

--- a/futurerestore/main.cpp
+++ b/futurerestore/main.cpp
@@ -195,7 +195,7 @@ int main_r(int argc, const char * argv[]) {
     }else if (argc == optind && flags & FLAG_WAIT) {
         info("User requested to only wait for ApNonce to match, but not for actually restoring\n");
     }else if (exitRecovery){
-        info("Exiting to recovery mode\n");
+        info("Exiting from recovery mode to normal mode\n");
     }else{
         error("argument parsing failed! agrc=%d optind=%d\n",argc,optind);
         if (idevicerestore_debug){


### PR DESCRIPTION
--exit-recovery wasn't working because the option assumed that the compiler would optimise out the call to `recovery_client_new` when `_client->recovery` already exists, this is not (no longer?) the case and caused everything to fail.

