### PR TITLE
Finally fix iPhone 11 family of devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.DS_Store
+.vscode
 *.a
 *.o
 *.la

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # futurerestore
-[![CI Building](https://img.shields.io/github/workflow/status/marijuanARM/futurerestore/ci)](https://img.shields.io/github/workflow/status/marijuanARM/futurerestore/ci)
+[![CI Building](https://img.shields.io/github/workflow/status/marijuanARM/futurerestore/CI)](https://github.com/marijuanARM/futurerestore/actions?workflow=CI)
 
 
 _It is a hacked up idevicerestore wrapper, which allows manually specifying SEP and Baseband for restoring._
-
-**THIS HAS NOT YET BEEN TESTED FOR a13 going to 14.3 USE AT YOUR OWN RISK**
 
 Latest compiled version can be found [here](https://github.com/marijuanARM/futurerestore/releases).
 

--- a/futurerestore/futurerestore.hpp
+++ b/futurerestore/futurerestore.hpp
@@ -19,6 +19,11 @@
 #include <stdio.h>
 #include <functional>
 #include <vector>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <string.h>
+#include <zip.h>
 #include "idevicerestore.h"
 #include <jssy.h>
 #include <plist/plist.h>
@@ -91,6 +96,11 @@ public:
     const char *getDeviceBoardNoCopy();
     char *getLatestManifest();
     char *getLatestFirmwareUrl();
+    void downloadLatestRose();
+    void downloadLatestSE();
+    void downloadLatestSavage();
+    void downloadLatestVeridian();
+    void downloadLatestFirmwareComponents();
     void loadLatestBaseband();
     void loadLatestSep();
     
@@ -119,6 +129,7 @@ public:
     static plist_t loadPlistFromFile(const char *path);
     static void saveStringToFile(const char *str, const char *path);
     static char *getPathOfElementInManifest(const char *element, const char *manifeststr, const char *model, int isUpdateInstall);
+    bool elemExists(const char *element, const char *manifeststr, const char *model, int isUpdateInstall);
     static std::string getGeneratorFromSHSH2(const plist_t shsh2);
 };
 

--- a/futurerestore/main.cpp
+++ b/futurerestore/main.cpp
@@ -257,7 +257,7 @@ int main_r(int argc, const char * argv[]) {
             if (!client.is32bit() && !(isSepManifestSigned = isManifestSignedForDevice(client.sepManifestPath(), &devVals, &versVals))){
                 reterror("SEP firmware doesn't signed\n");
             }
-            
+            client.downloadLatestFirmwareComponents();
             if (flags & FLAG_NO_BASEBAND){
                 printf("\nWARNING: user specified is not to flash a baseband. This can make the restore fail if the device needs a baseband!\n");
                 printf("if you added this flag by mistake, you can press CTRL-C now to cancel\n");


### PR DESCRIPTION
Download latest firmwareupdater components as a safeguard. Fall back to latest manifest and ipsw2 if firmwareupdater components fail tss. Also update readme and fix shields.io build message.