### PR TITLE
reduce boot-args

### DIFF
--- a/futurerestore/futurerestore.cpp
+++ b/futurerestore/futurerestore.cpp
@@ -1412,7 +1412,7 @@ void futurerestore::doRestore(const char *ipsw){
             if(!_isUpdateInstall) {
                 bootargs.append("nand-enable-reformat=0x1 ");
             }
-            bootargs.append("-v -restore debug=0x2014e keepsyms=0x1 amfi=0xff amfi_allow_any_signature=0x1 amfi_get_out_of_my_way=0x1 cs_enforcement_disable=0x1");
+            bootargs.append("-restore -progress");
         }
         enterPwnRecovery(build_identity, bootargs);
         irecv_device_event_unsubscribe(_client->irecv_e_ctx);


### PR DESCRIPTION
The previous bootargs patch caused a panic when restoring to 14.8(with ota blob) using --use-pwndfu on A9 (s8000).

`debug=0x2014e` will cause this panic.

```
iBoot Panic: : ARM synchronous abort at 0x0000000870019dd4:
 esr 0x92000006 (ec: 0x24 (Data Abort (EL0)), iss: 0x00000006) far 0x0000000000000065
 x0 0x0000000000000000 0x0000000000000034 0xffffffffffffffe0 0x000000087006ae30
 x4 0x000000087006ae10 0x0000000000000000 0x0000000000000000 0x0000000000000001
 x8 0x0000000000000000 0x00000008700625f0 0x000000087006adc8 0x0000000000000000
 x12 0x0000000000000001 0x000000087006aea8 0x0000000000000000 0x000000087f3f5000
 x16 0x0000000000001ef8 0x00000000000007bf 0x000000083e0f43f8 0x0000000000000065
 x20 0x0000000000000032 0x0000000870062630 0x00000002101fffff 0x00000000000000d0
 x24 0x0000000000000000 0x00000008700539b8 0x0000000000000000 0x00000001cdd37dc0
 x28 0x00000001cdd37e98 sp 0x00000001cdd37980 lr 0x0000000870019a98 spsr 0x80000000
```

Also, with odysseus's method, if you don't touch the restore ramdisk or rootfs, there should be no need to tamper with amfi.
