### PR TITLE
Fix m1sta API returns empty JSON

### DIFF
--- a/src/futurerestore.cpp
+++ b/src/futurerestore.cpp
@@ -1577,7 +1577,7 @@ void futurerestore::loadFirmwareTokens() {
     }
     if(!_betaFirmwareTokens && _useCustomLatestBeta) {
         if (!_betaFirmwareJson) _betaFirmwareJson = getBetaFirmwareJson(getDeviceModelNoCopy());
-        if(!_betaFirmwareJson) {
+        if(!_betaFirmwareJson || strcmp(_betaFirmwareJson, "[]") == 0) {
             info("[TSSC] Could not get betas json, falling back to appledb\n");
             _useAppleDB = true;
             std::string type("iOS");


### PR DESCRIPTION
At time of writing  https://api.m1sta.xyz/betas/iPhone10,6 returns `[]` an empty JSON array. But `futurerestore` doesn't automatically switch to https://api.appledb.dev/ios/ because 

https://github.com/1Conan/tsschecker/blob/ade3719c4c3e57256f9b48147ac92f7ecacff1f5/tsschecker/tsschecker.c#L515-L519

So the file `f` contains two chars and `getBetaFirmwareJson` doesn't return `NULL` but  `[]`. For this reason

https://github.com/futurerestore/futurerestore/blob/ca45da2fb075ccf2921bbc04d5aef74e3e71b743/src/futurerestore.cpp#L1580
 
is `false`. To solve the problem I added another simple condition.